### PR TITLE
nao apagar a sessao no logout

### DIFF
--- a/protected/controllers/LogoutController.php
+++ b/protected/controllers/LogoutController.php
@@ -5,7 +5,7 @@ class LogoutController extends SiteController
 	
     public function actionIndex()
     {
-        UserUtil::getDefaultWebUser()->logout();
+        UserUtil::getDefaultWebUser()->logout(false);
         $this->redirect(array('/home/index'));
     }
     


### PR DESCRIPTION
impede que o login do admin ou outro módulo seja perdido.

quando o admin fizer logoff irá continuar apagando a sessão por segurança
